### PR TITLE
[ECO-1687] Remove SSH requirement for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "processor"]
 	path = processor
-	url = git@github.com:econia-labs/aptos-indexer-processors.git
+	url = https://github.com/econia-labs/aptos-indexer-processors.git


### PR DESCRIPTION
Currently, the `.gitmodules` file that specifies submodules includes an SSH url for the target repository.

Make it a simple https path for enhanced accessibility