### PR TITLE
[ECO-1748] Add `get_top_markets` query

### DIFF
--- a/sql_extensions/Dockerfile
+++ b/sql_extensions/Dockerfile
@@ -6,5 +6,6 @@ WORKDIR /
 
 COPY sql_extensions/00000_init.sql .
 COPY sql_extensions/apply-sql-extensions.sh .
+COPY sql_extensions/migrations/ ./migrations/
 
 CMD ["bash", "./apply-sql-extensions.sh"]

--- a/sql_extensions/apply-sql-extensions.sh
+++ b/sql_extensions/apply-sql-extensions.sh
@@ -9,5 +9,6 @@ if [ -d "$script_dir/migrations" ]; then
         if [ "$(psql $DATABASE_URL --csv -t -c "SELECT COUNT(*) FROM sql_extensions WHERE name = '($(basename $file))'" 2>/dev/null)" != "1" ];then
             psql $DATABASE_URL --single-transaction -f "$file" -c "INSERT INTO sql_extensions VALUES ('$(basename $file)');"
         fi
+        psql $DATABASE_URL -t -c "NOTIFY pgrst, 'reload schema';"
     done
 fi

--- a/sql_extensions/migrations/00001_add_get_top_markets_function.sql
+++ b/sql_extensions/migrations/00001_add_get_top_markets_function.sql
@@ -1,4 +1,4 @@
--- migrations/00002_add_get_top_markets_function.sql
+-- migrations/00001_add_get_top_markets_function.sql
 
 -- Function to get the top markets by market_cap
 CREATE OR REPLACE FUNCTION get_top_markets(

--- a/sql_extensions/migrations/00001_add_get_top_markets_function.sql
+++ b/sql_extensions/migrations/00001_add_get_top_markets_function.sql
@@ -1,0 +1,25 @@
+-- migrations/00002_add_get_top_markets_function.sql
+
+-- Function to get the top markets by market_cap
+CREATE OR REPLACE FUNCTION get_top_markets(
+    module_address text
+)
+RETURNS TABLE (
+    transaction_version bigint,
+    data jsonb
+) AS $$
+BEGIN
+    RETURN QUERY
+    WITH latest_entries AS (
+        SELECT DISTINCT ON (e.data->'market_metadata'->'market_id') e.*
+        FROM public.inbox_events e
+        WHERE e.type = module_address || '::emojicoin_dot_fun::State'
+        ORDER BY e.data->'market_metadata'->'market_id', (e.data->'last_swap'->>'time')::bigint DESC
+    )
+    SELECT
+        le.transaction_version,
+        le.data
+    FROM latest_entries le
+    ORDER BY (le.data->'instantaneous_stats'->>'market_cap')::bigint DESC;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
- [ ] Make sql extension for simple get_top_markets query the usre will use every time they visit the home page
- [ ] The query should return the max amount of rows possible. Right now that's 500, which is perfect for what we need (we probably really only need 200-300)
  - [ ] Returns the last swap event data for the market. This is a nested jsonb field so sorting by this needs to occur as a precursor subquery (`WITH recent_events` or something)
  - [ ] It then takes those results and sorts by market_cap
  - [ ] Returns the top SwapEvents data with the transaction version attached as well (nice to have for explorer links)
- [ ] ?? We may need to add a simple, lighter query for all existing markets so the user can use the search bar