### PR TITLE
[ECO 1753] Fix `market_id` cast in `market_data` view, use `market_nonce` instead of `bump_time`

### DIFF
--- a/cfg/cspell-dictionary.txt
+++ b/cfg/cspell-dictionary.txt
@@ -37,6 +37,7 @@ mdformat
 mosquitto
 mqtt
 mqttoptions
+noqa
 notif
 pgrep
 plpgsql

--- a/sql_extensions/apply-sql-extensions.sh
+++ b/sql_extensions/apply-sql-extensions.sh
@@ -12,6 +12,7 @@ if [ -d "$script_dir/migrations" ]; then
             psql $DATABASE_URL --single-transaction -f "$file" -c "INSERT INTO sql_extensions VALUES ('$(basename $file)');"
         fi
     done
+    psql $DATABASE_URL -t -c "NOTIFY pgrst, 'reload schema';"
 fi
 
 echo "Migrations successfully applied."

--- a/sql_extensions/apply-sql-extensions.sh
+++ b/sql_extensions/apply-sql-extensions.sh
@@ -12,7 +12,6 @@ if [ -d "$script_dir/migrations" ]; then
             psql $DATABASE_URL --single-transaction -f "$file" -c "INSERT INTO sql_extensions VALUES ('$(basename $file)');"
         fi
     done
-    psql $DATABASE_URL -t -c "NOTIFY pgrst, 'reload schema';"
 fi
 
 echo "Migrations successfully applied."

--- a/sql_extensions/migrations/special-queries.sql
+++ b/sql_extensions/migrations/special-queries.sql
@@ -211,6 +211,7 @@ SELECT
     volume.all_time_volume,
     volume.daily_volume,
     (state.data -> 'market_metadata' ->> 'emoji_bytes') AS emoji_bytes,
+    (state.data -> 'market_metadata' ->> 'market_address') AS market_address,
     state.data -> 'clamm_virtual_reserves' AS clamm_virtual_reserves,
     state.data -> 'cpamm_real_reserves' AS cpamm_real_reserves
 FROM inbox_latest_state AS state, inbox_volume AS volume

--- a/sql_extensions/migrations/special-queries.sql
+++ b/sql_extensions/migrations/special-queries.sql
@@ -92,8 +92,7 @@ BEGIN
     transaction_block_height = EXCLUDED.transaction_block_height,
     data = EXCLUDED.data,
     inserted_at = EXCLUDED.inserted_at,
-    event_index = EXCLUDED.event_index
-  WHERE (inbox_latest_state.data->'state_metadata'->>'market_nonce')::numeric < (EXCLUDED.data->'state_metadata'->>'market_nonce')::numeric;
+    event_index = EXCLUDED.event_index;
 
   RETURN NEW;
 END;
@@ -102,7 +101,7 @@ $$ LANGUAGE plpgsql;
 CREATE TRIGGER update_latest_state
 AFTER INSERT ON inbox_events
 FOR EACH ROW
-WHEN (new.type LIKE '%::emojicoin_dot_fun::State')
+WHEN (new.event_name = 'emojicoin_dot_fun::State')
 EXECUTE PROCEDURE UPDATE_LATEST_STATE();
 
 CREATE INDEX inbox_latest_state_by_market_cap ON inbox_events (
@@ -214,7 +213,6 @@ SELECT
     (state.data -> 'market_metadata' ->> 'emoji_bytes') AS emoji_bytes,
     state.data -> 'clamm_virtual_reserves' AS clamm_virtual_reserves,
     state.data -> 'cpamm_real_reserves' AS cpamm_real_reserves
-
 FROM inbox_latest_state AS state, inbox_volume AS volume
 WHERE state.market_id = volume.market_id;
 

--- a/sql_extensions/migrations/special-queries.sql
+++ b/sql_extensions/migrations/special-queries.sql
@@ -56,7 +56,7 @@ BEGIN
     SELECT 1
     FROM inbox_latest_state
     WHERE (inbox_latest_state.data->'market_metadata'->>'market_id')::numeric = (NEW.data->'market_metadata'->>'market_id')::numeric
-      AND (inbox_latest_state.data->'state_metadata'->>'market_nonce')::numeric < (NEW.data->'state_metadata'->>'market_nonce')::numeric
+      AND (inbox_latest_state.data->'state_metadata'->>'market_nonce')::numeric > (NEW.data->'state_metadata'->>'market_nonce')::numeric
   ) THEN
     RETURN NEW;
   END IF;

--- a/sql_extensions/migrations/special-queries.sql
+++ b/sql_extensions/migrations/special-queries.sql
@@ -209,9 +209,9 @@ SELECT
     (state.data -> 'cumulative_stats' ->> 'n_chat_messages')::NUMERIC AS n_chat_messages,
     (state.data -> 'last_swap' ->> 'avg_execution_price_q64')::NUMERIC AS avg_execution_price_q64,
     (state.data ->> 'lp_coin_supply')::NUMERIC AS lp_coin_supply,
-    (state.data -> 'market_metadata' ->> 'emoji_bytes') AS emoji_bytes,
     volume.all_time_volume,
     volume.daily_volume,
+    (state.data -> 'market_metadata' ->> 'emoji_bytes') AS emoji_bytes,
     state.data -> 'clamm_virtual_reserves' AS clamm_virtual_reserves,
     state.data -> 'cpamm_real_reserves' AS cpamm_real_reserves
 

--- a/sql_extensions/migrations/special-queries.sql
+++ b/sql_extensions/migrations/special-queries.sql
@@ -197,6 +197,7 @@ SELECT
     (state.data -> 'cumulative_stats' ->> 'n_chat_messages')::NUMERIC AS n_chat_messages,
     (state.data -> 'last_swap' ->> 'avg_execution_price_q64')::NUMERIC AS avg_execution_price_q64,
     (state.data ->> 'lp_coin_supply')::NUMERIC AS lp_coin_supply,
+    (state.data -> 'market_metadata' ->> 'emoji_bytes') AS emoji_bytes,
     volume.all_time_volume,
     volume.daily_volume,
     state.data -> 'clamm_virtual_reserves' AS clamm_virtual_reserves,


### PR DESCRIPTION
`market_id` was being cast to a `jsonb` value instead of a `string` value, so the trigger event was failing

It also wasn't being added to `inbox_latest_state` because it's no longer a nested field
I also added extra columns for easier access to that data


- [x] Change market_id cast from NEW.data->'market_metadata'->'market_id' to NEW.data->'market_metadata'->>'market_id' 
- [x] Add `emoji_bytes` field
- [x] Use `market_nonce` instead of `bump_time`
- [x] Add attempted deadlock fix
- [x] (Bogdan) Left join volume and state tables to get any market, not just ones that have a swap event