### PR TITLE
[ECO-1779] fix daily_volume issues

### DIFF
--- a/cfg/cspell-dictionary.txt
+++ b/cfg/cspell-dictionary.txt
@@ -43,10 +43,12 @@ pgrep
 plpgsql
 psql
 readwrite
+recordset
 rumqttc
 rustls
 serde
 servicenetworking
+serviceusage
 sqladmin
 sqlfluff
 sqlx
@@ -58,5 +60,6 @@ testnet
 tfstate
 tfvars
 trimsuffix
+vercel
 vpcaccess
 websockets


### PR DESCRIPTION
This PR fixes the issue with stale daily volume data.

Every time a new periodic state event is emitted for a market, a function will run that would update that market's `volume_events` (all the volume events for that market in the last 24 hours). On query, the field `daily_volume` will be computed by iterating over those events and summing up all the quote volume for events which STILL are in the 24h window.