### PR TITLE
[ECO-1832] Add missing project_id variable declaration to postgrest Terraform module

### DIFF
--- a/terraform/modules/postgrest/variables.tf
+++ b/terraform/modules/postgrest/variables.tf
@@ -6,6 +6,8 @@ variable "no_auth_policy_data" {}
 
 variable "postgrest_max_rows" {}
 
+variable "project_id" {}
+
 variable "region" {}
 
 variable "sql_vpc_connector_id" {}


### PR DESCRIPTION
Add `project_id` variable to PostgREST module declaration, which was blocking `terraform apply`